### PR TITLE
:wrench: Correción del endpoint para reset-password

### DIFF
--- a/app/api/routes/v1/users/auth.py
+++ b/app/api/routes/v1/users/auth.py
@@ -17,6 +17,7 @@ from app.infraestructure.services.emails.user import recovery_password_email
 from app.schemas.users.user import User
 from app.schemas.users.user import UserCreateInDB
 from app.schemas.users.user import UserUpdate
+from app.schemas.users.user import UserUpdateInDB
 from app.services.crypt import crypt_svc
 from app.services.jwt import jwt_service
 from app.services.users.user import user_svc
@@ -159,7 +160,7 @@ def reset_password(
     except Exception:
         raise HTTPException(status_code=400, detail='Invalid token')
 
-    user: UserCreateInDB = user_svc.get_by_email(
+    user: UserUpdateInDB = user_svc.get_by_email(
         email=email,
         db=db_postgres,
     )

--- a/app/schemas/users/user.py
+++ b/app/schemas/users/user.py
@@ -1,11 +1,16 @@
-from pydantic import BaseModel, Field, EmailStr
+from __future__ import annotations
+
 from uuid import UUID
 
-from app.schemas.utils.base_model import GeneralResponse
-from app.schemas.users.rol import Rol
-from app.schemas.users.user_rol_academic_unit import UserRolAcademicUnit
+from pydantic import BaseModel
+from pydantic import EmailStr
+from pydantic import Field
 
 from app.infraestructure.db.models.user.user import IdentificationType
+from app.schemas.users.rol import Rol
+from app.schemas.users.user_rol_academic_unit import UserRolAcademicUnit
+from app.schemas.utils.base_model import GeneralResponse
+
 
 class UserBase(BaseModel):
     name: str
@@ -37,23 +42,33 @@ class UserUpdate(BaseModel):
     class Config:
         from_attributes = True
 
+
 class UserCreateInDB(UserBase):
-    id: UUID
     hashed_password: str
 
     class Config:
         from_attributes = True
+
+
+class UserUpdateInDB(UserBase):
+    id: UUID | None = None
+    hashed_password: str
+
+    class Config:
+        from_attributes = True
+
 
 class UserInDB(GeneralResponse, UserBase):
     ...
 
 
 class UserSearch(BaseModel):
-    names__icontains: str | None = Field(None, alias="names")
-    email__icontains: str | None = Field(None, alias="email")
+    names__icontains: str | None = Field(None, alias='names')
+    email__icontains: str | None = Field(None, alias='email')
 
     class Config:
         populate_by_name = True
+
 
 class User(UserBase):
     id: UUID


### PR DESCRIPTION
Se corrige el error del endpoint para reset-password que pedía id y hashedpassword. Se creó un esquema específicamente para entregar estos dos campos