### PR TITLE
get all users endopoint paginated

### DIFF
--- a/app/api/routes/v1/users/user.py
+++ b/app/api/routes/v1/users/user.py
@@ -22,6 +22,8 @@ from app.schemas.users.user_rol_academic_unit import UserRolAcademicUnit
 from app.schemas.users.user_rol_academic_unit import UserRolAcademicUnitCreate
 from app.services.users.user import user_svc
 from app.services.users.user_rol_academic_unit import user_rol_academic_unit_svc
+from app.schemas.users.user_pagination import PaginatedUsers
+from sqlalchemy.orm import Session
 
 router = APIRouter()
 
@@ -42,40 +44,38 @@ def create_user(
     return user
 
 
-@router.get('', response_model=list[UserInDB], status_code=200)
+@router.get('', status_code=200)
 def get_all_user(
-    *, skip: int = 0,
+    skip: int = 0,
     limit: int = 10,
-    db_postgres=Depends(get_db),
-    current_user: Annotated[
-        User, Security(
-        has_role, scopes=['admin'],
-        ),
-    ] = None,
-) -> list[UserInDB]:
-    return user_svc.get_multi(skip=skip, limit=limit, db=db_postgres)
+    db: Session = Depends(get_db),
+    current_user: Annotated[User, Security(has_role, scopes=["admin"])] = None,
+):
+    total = user_svc.count(db)
+    users = user_svc.get_multi(skip=skip, limit=limit, db=db)
+
+    return {
+        "total": total,
+        "total_pages": (total + limit - 1) // limit,
+        "users": [UserInDB.model_validate(user).model_dump() for user in users],
+    }
 
 
-@router.get('/{id}', response_model=User, status_code=200)
-def get_user(*, id: UUID, db_postgres=Depends(get_db)) -> User:
-    user = user_svc.get(id=id, db=db_postgres)
-    if not user:
-        raise HTTPException(404, 'User not found')
-    user = UserInDB.model_validate(user)
-    roles = user_rol_academic_unit_svc.get_by_user_id(
-        user_id=id, db=db_postgres,
+@router.get('', response_model=PaginatedUsers, status_code=200)
+def get_all_user(
+    skip: int = 0,
+    limit: int = 10,
+    db: Session = Depends(get_db),
+    current_user: Annotated[User, Security(has_role, scopes=["admin"])] = None,
+) -> PaginatedUsers:
+    total = user_svc.count(db)
+    users = user_svc.get_multi(skip=skip, limit=limit, db=db)
+
+    return PaginatedUsers(
+        total=total,
+        total_pages=(total + limit - 1) // limit,
+        users=[UserInDB.model_validate(user) for user in users]
     )
-
-    user_roles_academic_units = [
-        UserRolAcademicUnit.model_validate(role) for role in roles
-    ]
-
-    response = User(
-        **user.model_dump(),
-        user_roles_academic_units=user_roles_academic_units,
-    )
-    return response
-
 
 @router.patch('/{id}', response_model=None)
 def update_user(*, obj_in: UserUpdate, id: int) -> None:

--- a/app/protocols/db/crud/users/user.py
+++ b/app/protocols/db/crud/users/user.py
@@ -13,3 +13,6 @@ class CRUDUserProtocol(CRUDProtocol[User, UserCreateInDB, UserUpdate]):
 
     def get_by_identification(self, *, identification_number: str) -> User:
         ...
+
+    def get_multi(self, *, skip: int = 0, limit: int = 10) -> list[User]:
+        ...

--- a/app/schemas/users/user_pagination.py
+++ b/app/schemas/users/user_pagination.py
@@ -1,0 +1,11 @@
+# app/schemas/users/user_pagination.py
+from pydantic import BaseModel
+from typing import List
+from app.schemas.users.user import UserInDB
+
+class PaginatedUsers(BaseModel):
+    total: int
+    page: int
+    limit: int
+    pages: int
+    users: List[UserInDB]

--- a/app/services/users/user.py
+++ b/app/services/users/user.py
@@ -6,12 +6,14 @@ from app.infraestructure.security.jwt import jwt
 from app.infraestructure.services.emails.user import confirm_email
 from app.protocols.db.crud.users.user import CRUDUserProtocol
 from app.protocols.db.models.users.user import User
+from app.infraestructure.db.models.user.user import User as UserORM
 from app.schemas.users.user import UserCreate
 from app.schemas.users.user import UserCreateInDB
 from app.schemas.users.user import UserInDB
 from app.schemas.users.user import UserUpdate
 from app.services.base import ServiceBase
 from app.services.crypt import crypt_svc
+from sqlalchemy import select, func
 
 
 class UserService(
@@ -54,6 +56,10 @@ class UserService(
             identification_number=identification_number,
             db=db,
         )
+    def count(self, db):
+        stmt = select(func.count()).select_from(UserORM)
+        result = db.execute(stmt)
+        return result.scalar_one()
 
 
 user_svc = UserService()


### PR DESCRIPTION
Se reestructura la paginación de obtener a todos los usuarios para que en la respueseta de la solicitud se retorne el total de items y total de paginas con base en la solicitud del cliente, para que este mismo pueda hacer solicitudes por lotes a medida que el usuario seleccione una determinada página en el frontend